### PR TITLE
Add FastAPI congestion detection service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# RGV Congestion Service
+
+A FastAPI service that reads vehicle and path data from Redis and computes a simple congestion index for each grid cell.
+
+## Endpoints
+
+- `GET /health` – basic health check.
+- `GET /congestion` – returns cells where more than one vehicle or path step are present.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+python start.py
+```
+
+Configure the Redis connection with the `REDIS_URL` environment variable. The default is `redis://localhost:6379/0`.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,18 @@
+import asyncio
+from fastapi import FastAPI
+
+from .services import calculate_congestion, fetch_paths, fetch_vehicle_states
+
+app = FastAPI(title="RGV Congestion Service")
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/congestion")
+async def congestion() -> dict:
+    states, paths = await asyncio.gather(fetch_vehicle_states(), fetch_paths())
+    data = calculate_congestion(states, paths)
+    return {"congestion": data}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class VehicleState:
+    """Simplified vehicle state used for congestion calculation."""
+
+    id: int
+    row: int
+    col: int
+    target_row: int
+    target_col: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "VehicleState":
+        return cls(
+            id=data.get("Id", 0),
+            row=data.get("Row", 0),
+            col=data.get("Col", 0),
+            target_row=data.get("TargetRow", 0),
+            target_col=data.get("TargetCol", 0),
+        )
+
+
+@dataclass
+class PathEntry:
+    """A single step in a vehicle path."""
+
+    row: int
+    col: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PathEntry":
+        return cls(row=data.get("Row", 0), col=data.get("Col", 0))

--- a/app/redis_client.py
+++ b/app/redis_client.py
@@ -1,0 +1,10 @@
+import os
+import redis.asyncio as redis
+
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+
+def get_redis() -> redis.Redis:
+    """Return a Redis client instance."""
+    return redis.from_url(REDIS_URL)

--- a/app/services.py
+++ b/app/services.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+from .models import PathEntry, VehicleState
+from .redis_client import get_redis
+
+
+async def fetch_vehicle_states() -> List[VehicleState]:
+    client = get_redis()
+    keys = await client.keys("RGV:State:*")
+    if not keys:
+        return []
+    values = await asyncio.gather(*(client.get(key) for key in keys))
+    states = []
+    for value in values:
+        if not value:
+            continue
+        try:
+            data = json.loads(value)
+            states.append(VehicleState.from_dict(data))
+        except json.JSONDecodeError:
+            continue
+    return states
+
+
+async def fetch_paths() -> List[PathEntry]:
+    client = get_redis()
+    keys = await client.keys("Path:List:*")
+    paths: List[PathEntry] = []
+    for key in keys:
+        entries = await client.zrange(key, 0, -1)
+        for entry in entries:
+            try:
+                data = json.loads(entry)
+                paths.append(PathEntry.from_dict(data))
+            except json.JSONDecodeError:
+                continue
+    return paths
+
+
+def calculate_congestion(
+    states: List[VehicleState], paths: List[PathEntry]
+) -> List[Dict[str, int]]:
+    """Calculate congestion index for each grid cell.
+
+    Returns list of dictionaries with row, col and congestion count.
+    """
+    counts: Dict[Tuple[int, int], int] = defaultdict(int)
+
+    for state in states:
+        counts[(state.row, state.col)] += 1
+        counts[(state.target_row, state.target_col)] += 1
+
+    for path in paths:
+        counts[(path.row, path.col)] += 1
+
+    congestion = []
+    for (row, col), count in counts.items():
+        if count > 1:
+            congestion.append({"row": row, "col": col, "count": count})
+    return congestion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+redis

--- a/start.py
+++ b/start.py
@@ -1,11 +1,10 @@
 import uvicorn
-from main2 import app
 
 if __name__ == "__main__":
     uvicorn.run(
-        "main2:app",
+        "app.main:app",
         host="0.0.0.0",
         port=8000,
         reload=True,
-        log_level="info"
+        log_level="info",
     )


### PR DESCRIPTION
## Summary
- add FastAPI app for four-way vehicle congestion detection
- compute congestion index from RGV state and path data in Redis
- document setup and provide start script

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa52447b0832aae359c1bb44f3cdf